### PR TITLE
Feat/image loading improvement

### DIFF
--- a/components/Breeds/Hero.js
+++ b/components/Breeds/Hero.js
@@ -1,10 +1,12 @@
 import Image from "next/image";
 import { styled } from "styled-components";
+import StyledImage from "../Image.styled";
+import ImageWrapper from "../ImageWrapper.styled";
 
 export default function Hero({ breed, data }) {
   if (!data) return <p>is loading</p>;
   return (
-    <ImageWrapper>
+    <ImageWrapper $variant="hero">
       <StyledImage
         src={data.results.url}
         alt={breed.name}
@@ -15,28 +17,3 @@ export default function Hero({ breed, data }) {
     </ImageWrapper>
   );
 }
-
-const ImageWrapper = styled.div`
-  position: relative;
-  width: 100%;
-  height: 18rem;
-  border-radius: 0.25rem;
-  overflow: hidden;
-
-  & h1 {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    margin: 0;
-    padding: 1rem;
-    background-color: hsla(0, 0%, 100%, 0.75);
-    color: black;
-  }
-`;
-
-const StyledImage = styled(Image)`
-  width: 100%;
-  height: 100%;
-  background: lightblue;
-  object-fit: cover;
-`;

--- a/components/Breeds/Thumbnail.js
+++ b/components/Breeds/Thumbnail.js
@@ -5,28 +5,32 @@ import { keyframes, styled } from "styled-components";
 import { useState } from "react";
 
 export default function Thumbnail({ breed }) {
-  const [loader, setLoader] = useState(true);
-
   const { data, isLoading, error } = useSWR(
     `/api/dogBreeds/${breed && breed.reference_image_id}`
   );
-  if (error) return <div>failed to load</div>;
-  if (isLoading) return <div>loading...</div>;
-
-  return (
-    <ImageWrapper $variant="thumbnail">
-      {loader && (
+  if (error)
+    return (
+      <ImageWrapper $variant="thumbnail">
+        <div>failed</div>
+      </ImageWrapper>
+    );
+  if (isLoading)
+    return (
+      <ImageWrapper $variant="thumbnail">
         <LoaderWrapper>
           <Loader />
         </LoaderWrapper>
-      )}
+      </ImageWrapper>
+    );
+
+  return (
+    <ImageWrapper $variant="thumbnail">
       {data && (
         <StyledImage
           src={data.results.url}
           alt={breed.name}
           width={data.results.width}
           height={data.results.height}
-          onLoadingComplete={() => setLoader(false)}
         />
       )}
     </ImageWrapper>

--- a/components/Breeds/Thumbnail.js
+++ b/components/Breeds/Thumbnail.js
@@ -1,37 +1,57 @@
-import Image from "next/image";
-import { styled } from "styled-components";
 import useSWR from "swr";
+import StyledImage from "../Image.styled";
+import ImageWrapper from "../ImageWrapper.styled";
+import { keyframes, styled } from "styled-components";
+import { useState } from "react";
 
 export default function Thumbnail({ breed }) {
+  const [loader, setLoader] = useState(true);
+
   const { data, isLoading, error } = useSWR(
-    `/api/dogBreeds/${breed.reference_image_id}`
+    `/api/dogBreeds/${breed && breed.reference_image_id}`
   );
   if (error) return <div>failed to load</div>;
   if (isLoading) return <div>loading...</div>;
+
   return (
-    <ImageWrapper>
-      <StyledImage
-        src={data.results.url}
-        alt={breed.name}
-        width={data.results.width}
-        height={data.results.height}
-      />
+    <ImageWrapper $variant="thumbnail">
+      {loader && (
+        <LoaderWrapper>
+          <Loader />
+        </LoaderWrapper>
+      )}
+      {data && (
+        <StyledImage
+          src={data.results.url}
+          alt={breed.name}
+          width={data.results.width}
+          height={data.results.height}
+          onLoadingComplete={() => setLoader(false)}
+        />
+      )}
     </ImageWrapper>
   );
 }
-
-const ImageWrapper = styled.div`
-  position: relative;
-  width: 5rem;
-  height: 5rem;
-  border-radius: 0.25rem;
-  overflow: hidden;
+const loadingAnimation = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg)}
 `;
 
-const StyledImage = styled(Image)`
-  object-fit: cover;
-  aspect-ratio: 1 / 1;
-  background: lightblue;
-  width: 100%;
-  height: 100%;
+const LoaderWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: lightblue;
+  padding: 0.5rem;
+  width: 5rem;
+  height: 5rem;
+`;
+
+const Loader = styled.div`
+  border: 8px solid #f3f3f3; /* Light grey */
+  border-top: 8px solid #3498db; /* Blue */
+  border-radius: 50%;
+  width: 4rem;
+  height: 4rem;
+  animation: ${loadingAnimation} 2s linear infinite;
 `;

--- a/components/Button.js
+++ b/components/Button.js
@@ -1,8 +1,19 @@
 import { css, styled } from "styled-components";
 
-export default function Button({ type, onClick, buttonText, $variant }) {
+export default function Button({
+  type,
+  onClick,
+  buttonText,
+  $variant,
+  disabled,
+}) {
   return (
-    <StyledButton type={type} onClick={onClick} $variant={$variant}>
+    <StyledButton
+      type={type}
+      onClick={onClick}
+      $variant={$variant}
+      disabled={disabled}
+    >
       {buttonText}
     </StyledButton>
   );
@@ -16,6 +27,9 @@ const StyledButton = styled.button`
   border-radius: 0.5rem;
   border: none;
   background-color: lightgray;
+  &:hover {
+    filter: brightness(0.95);
+  }
 
   ${({ $variant }) =>
     $variant == "primary" &&
@@ -32,5 +46,14 @@ const StyledButton = styled.button`
     css`
       background-color: rgb(200, 100, 100);
       color: white;
+    `}
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      cursor: default;
+      background-color: #f1f1f1;
+      &:hover {
+        filter: unset;
+      }
     `}
 `;

--- a/components/Image.styled.js
+++ b/components/Image.styled.js
@@ -1,0 +1,10 @@
+import Image from "next/image";
+import { styled } from "styled-components";
+
+const StyledImage = styled(Image)`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+export default StyledImage;

--- a/components/ImageWrapper.styled.js
+++ b/components/ImageWrapper.styled.js
@@ -1,0 +1,33 @@
+import { css, styled } from "styled-components";
+
+const ImageWrapper = styled.div`
+  position: relative;
+  overflow: hidden;
+  background: lightblue;
+
+  ${({ $variant }) =>
+    $variant == "thumbnail" &&
+    css`
+      width: 5rem;
+      height: 5rem;
+      border-radius: 0.25rem;
+    `}
+  ${({ $variant }) =>
+    $variant == "hero" &&
+    css`
+      width: 100%;
+      height: 18rem;
+      border-radius: 0.25rem;
+      & h1 {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        margin: 0;
+        padding: 1rem;
+        background-color: hsla(0, 0%, 100%, 0.75);
+        color: black;
+      }
+    `}
+`;
+
+export default ImageWrapper;

--- a/components/ListItemWithImg.js
+++ b/components/ListItemWithImg.js
@@ -1,0 +1,13 @@
+import Thumbnail from "./Breeds/Thumbnail";
+import StyledLink from "./ListLink.styled";
+
+export default function ListItemWithImg({ breed }) {
+  return (
+    <li>
+      <StyledLink href={`/breeds/${breed.slug}`} $variant="breed">
+        <Thumbnail breed={breed} />
+        <h3>{breed.name}</h3>
+      </StyledLink>
+    </li>
+  );
+}

--- a/components/ListLink.styled.js
+++ b/components/ListLink.styled.js
@@ -21,6 +21,7 @@ const StyledLink = styled(Link)`
       align-items: center;
       gap: 1rem;
       padding: 0.5rem;
+      height: 96px;
     `};
 `;
 

--- a/pages/breeds/index.js
+++ b/pages/breeds/index.js
@@ -11,7 +11,7 @@ import StyledForm from "@/components/Form/Form.styled";
 import StyledList from "@/components/List.styled";
 import Select from "@/components/Form/Select.styled";
 import { dogBreedFilter } from "@/utils/dogBreedFilter";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import ListItemWithImg from "@/components/ListItemWithImg";
 import Button from "@/components/Button";
 import useLocalStorageState from "use-local-storage-state";
@@ -43,7 +43,8 @@ export default function BreedList({ dogBreeds }) {
 
   useEffect(() => {
     setSliceOptions(initialSliceOptions);
-  }, [setSliceOptions, breedsToShowCount]);
+  }, [setSliceOptions, filter]);
+
   return (
     <Container>
       <FilterForm $isRow>
@@ -122,13 +123,17 @@ export default function BreedList({ dogBreeds }) {
         <ButtonWrapper>
           <Button
             type="button"
-            onClick={handlePrevious}
+            onClick={() =>
+              handlePrevious(sliceOptions, setSliceOptions, breedsToShowCount)
+            }
             buttonText="Previous"
             disabled={sliceOptions.prevDisabled}
           />
           <Button
             type="button"
-            onClick={handleNext}
+            onClick={() =>
+              handleNext(sliceOptions, setSliceOptions, breedsToShowCount)
+            }
             buttonText="Next"
             disabled={sliceOptions.nextDisabled}
           />

--- a/pages/breeds/index.js
+++ b/pages/breeds/index.js
@@ -38,12 +38,22 @@ export default function BreedList({ dogBreeds }) {
     defaultValue: initialSliceOptions,
   });
 
-  const breedsToShow = dogBreedFilter(filter, dogBreeds && dogBreeds);
+  const breedsToShow = dogBreedFilter(
+    filter,
+    dogBreeds && dogBreeds,
+    setSliceOptions,
+    initialSliceOptions
+  );
   const breedsToShowCount = breedsToShow?.length;
 
-  useEffect(() => {
+  function handleOnChange(event, key) {
+    const newFilter = {
+      ...filter,
+    };
+    newFilter[key] = event.target.value;
+    setFilter(newFilter);
     setSliceOptions(initialSliceOptions);
-  }, [setSliceOptions, filter]);
+  }
 
   return (
     <Container>
@@ -53,9 +63,7 @@ export default function BreedList({ dogBreeds }) {
           <Select
             name="breedGroup"
             id="breedGroup"
-            onChange={(event) =>
-              setFilter({ ...filter, group: event.target.value })
-            }
+            onChange={(event) => handleOnChange(event, "group")}
             defaultValue={filter.group}
           >
             <option key="all" value="all">
@@ -73,9 +81,7 @@ export default function BreedList({ dogBreeds }) {
           <Select
             name="breedTemperament"
             id="breedTemperament"
-            onChange={(event) =>
-              setFilter({ ...filter, temperament: event.target.value })
-            }
+            onChange={(event) => handleOnChange(event, "temperament")}
             defaultValue={filter.temperament}
           >
             <option key="all" value="all">
@@ -93,9 +99,7 @@ export default function BreedList({ dogBreeds }) {
           <Select
             name="breedSize"
             id="breedSize"
-            onChange={(event) =>
-              setFilter({ ...filter, size: event.target.value })
-            }
+            onChange={(event) => handleOnChange(event, "size")}
             defaultValue={filter.size}
           >
             <option key="all" value="all">

--- a/pages/breeds/index.js
+++ b/pages/breeds/index.js
@@ -38,12 +38,7 @@ export default function BreedList({ dogBreeds }) {
     defaultValue: initialSliceOptions,
   });
 
-  const breedsToShow = dogBreedFilter(
-    filter,
-    dogBreeds && dogBreeds,
-    setSliceOptions,
-    initialSliceOptions
-  );
+  const breedsToShow = dogBreedFilter(filter, dogBreeds && dogBreeds);
   const breedsToShowCount = breedsToShow?.length;
 
   function handleOnChange(event, key) {

--- a/pages/breeds/index.js
+++ b/pages/breeds/index.js
@@ -13,7 +13,9 @@ import StyledList from "@/components/List.styled";
 import StyledLink from "@/components/ListLink.styled";
 import Select from "@/components/Form/Select.styled";
 import { dogBreedFilter } from "@/utils/dogBreedFilter";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import ListItemWithImg from "@/components/ListItemWithImg";
+import Button from "@/components/Button";
 
 const initialFilter = {
   group: "all",
@@ -23,8 +25,60 @@ const initialFilter = {
 
 export default function BreedList({ dogBreeds }) {
   const [filter, setFilter] = useState(initialFilter);
+  const [sliceOptions, setSliceOptions] = useState({
+    start: 0,
+    end: 10,
+    prevDisabled: true,
+    nextDisabled: false,
+  });
 
   const breedsToShow = dogBreedFilter(filter, dogBreeds);
+  const breedsToShowCount = breedsToShow?.length;
+
+  let newSliceOptions = {};
+
+  function checkRange(newSliceOptions) {
+    if (newSliceOptions.start === 0) {
+      newSliceOptions = {
+        start: 0,
+        end: 10,
+        prevDisabled: true,
+        nextDisabled: false,
+      };
+      setSliceOptions(newSliceOptions);
+    }
+
+    if (newSliceOptions.end > breedsToShowCount) {
+      newSliceOptions = {
+        start: newSliceOptions.start,
+        end: newSliceOptions.end,
+        prevDisabled: false,
+        nextDisabled: true,
+      };
+      setSliceOptions(newSliceOptions);
+    }
+    setSliceOptions(newSliceOptions);
+  }
+
+  function handlePrevious() {
+    newSliceOptions = {
+      start: sliceOptions.start - 10,
+      end: sliceOptions.end - 10,
+      prevDisabled: false,
+      nextDisabled: false,
+    };
+    checkRange(newSliceOptions);
+  }
+
+  function handleNext() {
+    newSliceOptions = {
+      start: sliceOptions.start + 10,
+      end: sliceOptions.end + 10,
+      prevDisabled: false,
+      nextDisabled: false,
+    };
+    checkRange(newSliceOptions);
+  }
 
   return (
     <Container>
@@ -90,16 +144,25 @@ export default function BreedList({ dogBreeds }) {
           </Select>
         </Wrapper>
       </FilterForm>
+      <ButtonWrapper>
+        <Button
+          type="button"
+          onClick={handlePrevious}
+          buttonText="Previous"
+          disabled={sliceOptions.prevDisabled}
+        />
+        <Button
+          type="button"
+          onClick={handleNext}
+          buttonText="Next"
+          disabled={sliceOptions.nextDisabled}
+        />
+      </ButtonWrapper>
       <StyledList>
         {breedsToShow && breedsToShow.length > 0 ? (
-          breedsToShow.map((breed) => (
-            <li key={breed.id}>
-              <StyledLink href={`/breeds/${breed.slug}`} $variant="breed">
-                <Thumbnail breed={breed} />
-                <h3>{breed.name}</h3>
-              </StyledLink>
-            </li>
-          ))
+          breedsToShow
+            .slice(sliceOptions.start, sliceOptions.end)
+            .map((breed) => <ListItemWithImg breed={breed} key={breed.id} />)
         ) : (
           <p>There is no matching breed. Please try another combination</p>
         )}
@@ -113,4 +176,13 @@ const FilterForm = styled(StyledForm)`
   & div {
     width: 100%;
   }
+`;
+
+const ButtonWrapper = styled.div`
+  width: 100%;
+  margin-bottom: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
 `;

--- a/utils/dogBreedFilter.js
+++ b/utils/dogBreedFilter.js
@@ -7,7 +7,7 @@ export function dogBreedFilter(filter, dogBreeds) {
             breed.temperament && breed.temperament.includes(filter.temperament)
           );
         });
-  console.log(filter, filteredByTemperatment);
+
   const filteredByBreedGroup =
     filter.group === "all"
       ? filteredByTemperatment

--- a/utils/dogBreedFilter.js
+++ b/utils/dogBreedFilter.js
@@ -2,23 +2,23 @@ export function dogBreedFilter(filter, dogBreeds) {
   const filteredByTemperatment =
     filter.temperament === "all"
       ? dogBreeds
-      : dogBreeds.filter((breed) => {
+      : dogBreeds?.filter((breed) => {
           return (
             breed.temperament && breed.temperament.includes(filter.temperament)
           );
         });
-
+  console.log(filter, filteredByTemperatment);
   const filteredByBreedGroup =
     filter.group === "all"
       ? filteredByTemperatment
-      : filteredByTemperatment.filter(
+      : filteredByTemperatment?.filter(
           (breed) => breed.breed_group === filter.group
         );
 
   const filteredBySize =
     filter.size === "all"
       ? filteredByBreedGroup
-      : filteredByBreedGroup.filter((breed) => {
+      : filteredByBreedGroup?.filter((breed) => {
           return (
             (filter.size === "small" && getHeight(breed) < 4) ||
             (filter.size === "medium" &&
@@ -28,7 +28,6 @@ export function dogBreedFilter(filter, dogBreeds) {
           );
         });
 
-  /* setBreedsToShow(filteredBySize); */
   return filteredBySize;
 }
 

--- a/utils/handleBreedPages.js
+++ b/utils/handleBreedPages.js
@@ -1,0 +1,44 @@
+let newSliceOptions = {};
+
+function checkRange(newSliceOptions) {
+  if (newSliceOptions.start === 0) {
+    newSliceOptions = {
+      start: 0,
+      end: 10,
+      prevDisabled: true,
+      nextDisabled: false,
+    };
+    setSliceOptions(newSliceOptions);
+  }
+
+  if (newSliceOptions.end > breedsToShowCount) {
+    newSliceOptions = {
+      start: newSliceOptions.start,
+      end: newSliceOptions.end,
+      prevDisabled: false,
+      nextDisabled: true,
+    };
+    setSliceOptions(newSliceOptions);
+  }
+  setSliceOptions(newSliceOptions);
+}
+
+export function handlePrevious() {
+  newSliceOptions = {
+    start: sliceOptions.start - 10,
+    end: sliceOptions.end - 10,
+    prevDisabled: false,
+    nextDisabled: false,
+  };
+  checkRange(newSliceOptions);
+}
+
+export function handleNext() {
+  newSliceOptions = {
+    start: sliceOptions.start + 10,
+    end: sliceOptions.end + 10,
+    prevDisabled: false,
+    nextDisabled: false,
+  };
+  checkRange(newSliceOptions);
+}

--- a/utils/handleBreedPages.js
+++ b/utils/handleBreedPages.js
@@ -1,6 +1,6 @@
 let newSliceOptions = {};
 
-function checkRange(newSliceOptions) {
+function checkRange(newSliceOptions, setSliceOptions, breedsToShowCount) {
   if (newSliceOptions.start === 0) {
     newSliceOptions = {
       start: 0,
@@ -23,22 +23,26 @@ function checkRange(newSliceOptions) {
   setSliceOptions(newSliceOptions);
 }
 
-export function handlePrevious() {
+export function handlePrevious(
+  sliceOptions,
+  setSliceOptions,
+  breedsToShowCount
+) {
   newSliceOptions = {
     start: sliceOptions.start - 10,
     end: sliceOptions.end - 10,
     prevDisabled: false,
     nextDisabled: false,
   };
-  checkRange(newSliceOptions);
+  checkRange(newSliceOptions, setSliceOptions, breedsToShowCount);
 }
 
-export function handleNext() {
+export function handleNext(sliceOptions, setSliceOptions, breedsToShowCount) {
   newSliceOptions = {
     start: sliceOptions.start + 10,
     end: sliceOptions.end + 10,
     prevDisabled: false,
     nextDisabled: false,
   };
-  checkRange(newSliceOptions);
+  checkRange(newSliceOptions, setSliceOptions, breedsToShowCount);
 }

--- a/utils/handleBreedPages.js
+++ b/utils/handleBreedPages.js
@@ -14,7 +14,7 @@ function checkRange(newSliceOptions, setSliceOptions, breedsToShowCount) {
   if (newSliceOptions.end > breedsToShowCount) {
     newSliceOptions = {
       start: newSliceOptions.start,
-      end: newSliceOptions.end,
+      end: newSliceOptions.start + 10,
       prevDisabled: false,
       nextDisabled: true,
     };


### PR DESCRIPTION
- the breeds list shows now only ten at a time
- there are two buttons on the bottom to switch "pages"
- added a function to track the sliceOptions (I used slice on the array that shows the breeds)
- prev / next button are diabled when the user gets to first or the last breed on the list
- when filtering the breeds I reset the sliceOptions in order to fixed the issue that I used jumps of ten

I put everything in the localstorage so the user does not have to filter again, when coming back to this page
that works for the filter, but not for the pages. When i go to page two, click on one breed and then go back, I got back on page one.